### PR TITLE
[#38] [hotKeys and quickActions] full/split view toggle

### DIFF
--- a/libs/skiff-crypto/CONTRIBUTING.md
+++ b/libs/skiff-crypto/CONTRIBUTING.md
@@ -76,7 +76,7 @@ The core team will promptly review your Pull Request and either merge it or requ
 ### How to structure Pull Requests?
 
 - All branches should be targeted at `main`.
-- The reference issue number should be include in the branch name.
+- The reference issue number should be included in the branch name.
 - Pull Request titles should be formated as `[Issue #] [Component] Imperative description`. For example, `[#1045] [Button] Add force theme support.`
 - There should be a description for the reviewer on how the code is structured and what to review.
 - All code should be linted, well-formated, and type-safe (running `yarn prettier`, `yarn lint`, and `yarn typescript`)

--- a/libs/skiff-front-utils/src/hooks/useUserPreference.ts
+++ b/libs/skiff-front-utils/src/hooks/useUserPreference.ts
@@ -97,14 +97,7 @@ export default function useUserPreference<T extends keyof AllUserPreferences>(
   };
 
   const setRemoteValue = async (newValue: AllUserPreferences[T]) => {
-    await setPreference({
-      variables: {
-        request: {
-          [preference]: newValue
-        }
-      },
-      refetchQueries: [{ query: GetUserPreferencesDocument }]
-    });
+    // Note: Removing remote setUserPreference call.
     UserPreferencesEE.emit(preference, newValue);
   };
 

--- a/libs/skiff-front-utils/src/hooks/useUserPreference.ts
+++ b/libs/skiff-front-utils/src/hooks/useUserPreference.ts
@@ -1,10 +1,6 @@
 import EventEmitter from 'eventemitter3';
 import { useState, useEffect } from 'react';
-import {
-  useSetUserPreferencesMutation,
-  useGetUserPreferencesQuery,
-  GetUserPreferencesDocument
-} from 'skiff-front-graphql';
+import { useGetUserPreferencesQuery } from 'skiff-front-graphql';
 
 import {
   DEFAULT_LOCAL_SETTINGS,
@@ -81,7 +77,6 @@ export default function useUserPreference<T extends keyof AllUserPreferences>(
   const [currentValue, setCurrentValue] = useState<AllUserPreferences[T]>(DEFAULT_ALL_USER_PREFERENCES[preference]);
 
   const { data } = useGetUserPreferencesQuery();
-  const [setPreference] = useSetUserPreferencesMutation();
   const preferenceInLocalStorage = isLocalSettingsKey(preference);
 
   /* Define setter functions */
@@ -97,7 +92,7 @@ export default function useUserPreference<T extends keyof AllUserPreferences>(
   };
 
   const setRemoteValue = async (newValue: AllUserPreferences[T]) => {
-    // Note: Removing remote setUserPreference call.
+    // Note: Remiv out remote setUserPreference
     UserPreferencesEE.emit(preference, newValue);
   };
 

--- a/skiff-mail-web/__mocks__/mockApiResponse.ts
+++ b/skiff-mail-web/__mocks__/mockApiResponse.ts
@@ -1,3 +1,17 @@
+import { MockedResponse } from '@apollo/client/testing';
+import { UserLabelsDocument } from 'skiff-front-graphql';
+
+export const MOCK_USER_LABELS_RESPONSE: MockedResponse = {
+  request: {
+    query: UserLabelsDocument
+  },
+  result: {
+    data: {
+      userLabels: []
+    }
+  }
+};
+
 export const MOCK_MAILBOX_REQUEST = {
   data: {
     mailbox: {

--- a/skiff-mail-web/components/shared/hotKeys/GlobalHotKeys.tsx
+++ b/skiff-mail-web/components/shared/hotKeys/GlobalHotKeys.tsx
@@ -13,7 +13,6 @@ import { useAvailableUserLabels } from '../../../hooks/useAvailableLabels';
 import { useThreadActions } from '../../../hooks/useThreadActions';
 import { skemailHotKeysReducer } from '../../../redux/reducers/hotkeysReducer';
 import { skemailMailboxReducer } from '../../../redux/reducers/mailboxReducer';
-import { skemailSettingsReducer } from 'redux/reducers/settingsReducer';
 import { ComposeExpandTypes, skemailModalReducer } from '../../../redux/reducers/modalReducer';
 import { ModalType } from '../../../redux/reducers/modalTypes';
 import { getLabelFromPathParams, isPlainLabel, LABEL_TO_SYSTEM_LABEL } from '../../../utils/label';

--- a/skiff-mail-web/components/shared/hotKeys/GlobalHotKeys.tsx
+++ b/skiff-mail-web/components/shared/hotKeys/GlobalHotKeys.tsx
@@ -3,8 +3,9 @@ import { useRouter } from 'next/router';
 import React, { useCallback, useMemo } from 'react';
 import { GlobalHotKeys, configure } from 'react-hotkeys';
 import { useDispatch } from 'react-redux';
-import { TabPage, isReactNativeDesktopApp } from 'skiff-front-utils';
-import { SystemLabels } from 'skiff-graphql';
+import { TabPage, isReactNativeDesktopApp, useUserPreference } from 'skiff-front-utils';
+import { SystemLabels, ThreadDisplayFormat } from 'skiff-graphql';
+import { StorageTypes } from 'skiff-utils';
 
 import { useAppSelector } from '../../../hooks/redux/useAppSelector';
 import { useActiveThreadActions } from '../../../hooks/useActiveThreadActions';
@@ -12,6 +13,7 @@ import { useAvailableUserLabels } from '../../../hooks/useAvailableLabels';
 import { useThreadActions } from '../../../hooks/useThreadActions';
 import { skemailHotKeysReducer } from '../../../redux/reducers/hotkeysReducer';
 import { skemailMailboxReducer } from '../../../redux/reducers/mailboxReducer';
+import { skemailSettingsReducer } from 'redux/reducers/settingsReducer';
 import { ComposeExpandTypes, skemailModalReducer } from '../../../redux/reducers/modalReducer';
 import { ModalType } from '../../../redux/reducers/modalTypes';
 import { getLabelFromPathParams, isPlainLabel, LABEL_TO_SYSTEM_LABEL } from '../../../utils/label';
@@ -49,6 +51,8 @@ const GlobalHotkeys = () => {
 
   const { archiveThreads, trashThreads, moveThreads, setActiveThreadID, removeUserLabel, activeThreadID } =
     useThreadActions();
+
+  const [threadFormat, setThreadFormat] = useUserPreference(StorageTypes.THREAD_FORMAT);
 
   const { reply, replyAll, forward, activeThreadLabels } = useActiveThreadActions();
 
@@ -220,6 +224,18 @@ const GlobalHotkeys = () => {
     [archiveThreads, isTrashOrArchive, isDrafts, selectedThreadIDs, activeThreadID]
   );
 
+  // change format between split and full
+  const threadFormatHandler = useCallback(
+    (e?: KeyboardEvent) => {
+      e?.preventDefault();
+      e?.stopImmediatePropagation();
+
+      // act like a toggle, if threadFormat is full, set it to right and vice versa
+      setThreadFormat(threadFormat === ThreadDisplayFormat.Full ? ThreadDisplayFormat.Right : ThreadDisplayFormat.Full);
+    },
+    [threadFormat, setThreadFormat]
+  );
+
   // trash threads
   const trashHandler = useCallback(
     (e?: KeyboardEvent) => {
@@ -326,15 +342,15 @@ const GlobalHotkeys = () => {
         preventWhenMetaPressed?: boolean;
       }
     ) =>
-    (e: KeyboardEvent | undefined) => {
-      // Disable all hot keys if a dropdown is open
-      if (e && isDropdownOpen(e)) return;
+      (e: KeyboardEvent | undefined) => {
+        // Disable all hot keys if a dropdown is open
+        if (e && isDropdownOpen(e)) return;
 
-      const inInput = e && INPUT_TAGS.includes((e.target as HTMLElement).tagName.toLowerCase());
-      if (preventWhenTyping && (isComposing || inInput)) return;
-      if (preventWhenMetaPressed && e?.metaKey) return;
-      handler(e);
-    };
+        const inInput = e && INPUT_TAGS.includes((e.target as HTMLElement).tagName.toLowerCase());
+        if (preventWhenTyping && (isComposing || inInput)) return;
+        if (preventWhenMetaPressed && e?.metaKey) return;
+        handler(e);
+      };
 
   const singleKeyHandlers: HotKeyHandlers<typeof globalSingleKeyMap> = {
     [GlobalKeyActions.OPEN_COMMAND_PALETTE]: wrapActionHandler(cmdPHandler, {}),
@@ -345,6 +361,7 @@ const GlobalHotkeys = () => {
     [GlobalKeyActions.ENTER]: wrapActionHandler(enterHandler, {}),
     [GlobalKeyActions.SELECT_THREAD]: wrapActionHandler(selectHandler, {}),
     [GlobalKeyActions.ARCHIVE]: wrapActionHandler(archiveHandler, {}),
+    [GlobalKeyActions.THREAD_FORMAT]: wrapActionHandler(threadFormatHandler, {}),
     [GlobalKeyActions.UNDO]: wrapActionHandler(undoHandler, {}),
     [GlobalKeyActions.REPLY_ALL]: wrapActionHandler(replyAll, { preventWhenMetaPressed: true }),
     [GlobalKeyActions.REPLY]: wrapActionHandler(reply, { preventWhenMetaPressed: true }),

--- a/skiff-mail-web/components/shared/hotKeys/hotKeys.ts
+++ b/skiff-mail-web/components/shared/hotKeys/hotKeys.ts
@@ -6,6 +6,7 @@ export enum GlobalKeyActions {
   DOWN_ARROW = 'DOWN_ARROW',
   ENTER = 'ENTER',
   SELECT_THREAD = 'SELECT_THREAD',
+  THREAD_FORMAT = 'THREAD_FORMAT',
   ARCHIVE = 'ARCHIVE',
   TRASH = 'TRASH',
   UNDO = 'UNDO',
@@ -31,6 +32,7 @@ export const globalSingleKeyMap = {
   [GlobalKeyActions.DOWN_ARROW]: ['s', 'down'],
   [GlobalKeyActions.ENTER]: ['Enter'],
   [GlobalKeyActions.SELECT_THREAD]: 'x',
+  [GlobalKeyActions.THREAD_FORMAT]: 't',  // 't' for toggle
   [GlobalKeyActions.ARCHIVE]: 'e',
   [GlobalKeyActions.UNDO]: 'z',
   /**

--- a/skiff-mail-web/hooks/useQuickActions.tsx
+++ b/skiff-mail-web/hooks/useQuickActions.tsx
@@ -97,7 +97,7 @@ export const useQuickActions = (query: string): Array<SearchAction> => {
       undefined // no shortcut
     );
     const toggleThreadFormatAction = createAction(
-      'Toggle full/split view',
+      `Switch to ${threadFormat === ThreadDisplayFormat.Full ? 'split' : 'full'} view`,
       () => void toggleThreadFormat(),
       { icon: threadFormat === ThreadDisplayFormat.Full ? Icon.FullView : Icon.SplitView },
       'T'

--- a/skiff-mail-web/pages/_app.tsx
+++ b/skiff-mail-web/pages/_app.tsx
@@ -23,6 +23,7 @@ import store from '../redux/store/reduxStore';
 import { CustomHTML5Backend } from '../utils/dragAndDrop';
 import { MOCK_USER } from '__mocks__/mockUser';
 import { MockedProvider } from '@apollo/client/testing';
+import { MOCK_USER_LABELS_RESPONSE } from '__mocks__/mockApiResponse';
 
 function CustomApp({ Component, pageProps }: AppProps) {
   useEffect(() => {
@@ -30,7 +31,7 @@ function CustomApp({ Component, pageProps }: AppProps) {
   }, []);
   return (
     <ErrorBoundary FallbackComponent={() => <ErrorPage client={client} origin='Skemail' />}>
-      <MockedProvider>
+      <MockedProvider mocks={[MOCK_USER_LABELS_RESPONSE]}>
         <Provider store={store}>
           <AppThemeProvider>
             <DndProvider backend={CustomHTML5Backend}>


### PR DESCRIPTION
This PR is directly aimed at a feature request tagged with "good first issue", see #38 

**_skiff-mail-web/components/shared/hotKeys/GlobalHotKeys.tsx_:**

- Imports: useUserPreference (hook) from skiff-front-utils and ThreadDisplayFormat (type) from skiff-graphql
- Introduced state handling for threadFormat, using the useUserPreference hook. This enables the component to access and modify the user's preferred view setting.
- Defined a new callback threadFormatHandler that handles the changing of the thread format between split and full views. It acts as a toggle.
- Added the previously defined threadFormatHandler to the global hotkeys, binding it to the specified action key `t` for toggling the thread format.

**_skiff-mail-web/hooks/useQuickActions.tsx_:**

- Imports: useUserPreference (hook) from skiff-front-utils, ThreadDisplayFormat (type) from skiff-graphql, and StorageTypes (enum) from skiff-utils
- Introduced state handling for threadFormat, using the useUserPreference hook. This allows the component to access and modify the user's preferred view setting.
- Defined a new callback toggleThreadFormat that handles the toggling of the thread format between full and split views.
- Added new action toggleThreadFormatAction that triggers the previously defined toggle callback. The action icon is dynamically chosen based on the current thread format.

_libs/skiff-crypto/CONTRIBUTING.md_: Found a typo
_skiff-mail-web/components/shared/hotKeys/hotKeys.ts_: Add `THREAD_FORMAT` and keybinding `t`