### PR TITLE
[#85] [MailEditor] Add markdown support for horizontal lines

### DIFF
--- a/skiff-mail-web/components/MailEditor/Extensions/EditorNodes.ts
+++ b/skiff-mail-web/components/MailEditor/Extensions/EditorNodes.ts
@@ -1,3 +1,4 @@
+import HorizontalRule from '@tiptap/extension-horizontal-rule'
 import Document from '@tiptap/extension-document';
 import Heading from '@tiptap/extension-heading';
 import Paragraph from '@tiptap/extension-paragraph';
@@ -12,9 +13,10 @@ import { OrderedList } from '../OrderedList';
 
 import { EditorExtensionsOptions } from './ExtensionsOptions';
 
-export { BulletList, Document, Heading, ListItem, OrderedList, Paragraph, Text, Blockquote, Image };
+export { HorizontalRule, BulletList, Document, Heading, ListItem, OrderedList, Paragraph, Text, Blockquote, Image };
 
 export const buildEditorNodes = (options?: EditorExtensionsOptions) => [
+  HorizontalRule,
   Document,
   Paragraph.configure({
     HTMLAttributes: {

--- a/skiff-mail-web/components/MailEditor/Extensions/EditorNodes.ts
+++ b/skiff-mail-web/components/MailEditor/Extensions/EditorNodes.ts
@@ -16,7 +16,6 @@ import { EditorExtensionsOptions } from './ExtensionsOptions';
 export { HorizontalRule, BulletList, Document, Heading, ListItem, OrderedList, Paragraph, Text, Blockquote, Image };
 
 export const buildEditorNodes = (options?: EditorExtensionsOptions) => [
-  HorizontalRule,
   Document,
   Paragraph.configure({
     HTMLAttributes: {
@@ -28,6 +27,11 @@ export const buildEditorNodes = (options?: EditorExtensionsOptions) => [
   BulletList,
   ListItem,
   OrderedList,
+  HorizontalRule.configure({
+    HTMLAttributes: {
+      style: 'border: none; border-top: 1px solid var(--border-primary); margin: 0px; padding: 0px;'
+    }
+  }),
   Image,
   HardBreak,
   Blockquote.configure({

--- a/skiff-mail-web/components/MailEditor/editor.css
+++ b/skiff-mail-web/components/MailEditor/editor.css
@@ -88,3 +88,10 @@
 .ProseMirror ol ol ol ol {
   list-style-type: decimal;
 }
+
+.ProseMirror hr {
+  margin: 16px auto;
+  background: #7d7d7d;
+  border: none;
+  height: 1px;
+}

--- a/skiff-mail-web/components/MailEditor/editor.css
+++ b/skiff-mail-web/components/MailEditor/editor.css
@@ -88,10 +88,3 @@
 .ProseMirror ol ol ol ol {
   list-style-type: decimal;
 }
-
-.ProseMirror hr {
-  margin: 16px auto;
-  background: #7d7d7d;
-  border: none;
-  height: 1px;
-}

--- a/skiff-mail-web/package.json
+++ b/skiff-mail-web/package.json
@@ -43,6 +43,7 @@
     "@tiptap/extension-heading": "^2.0.0-beta.26",
     "@tiptap/extension-highlight": "^2.0.0-beta.220",
     "@tiptap/extension-history": "^2.0.0-beta.21",
+    "@tiptap/extension-horizontal-rule": "^2.0.4",
     "@tiptap/extension-image": "^2.0.0-beta.27",
     "@tiptap/extension-italic": "^2.0.0-beta.26",
     "@tiptap/extension-link": "^2.0.0-beta.36",

--- a/skiff-mail-web/package.json
+++ b/skiff-mail-web/package.json
@@ -43,7 +43,7 @@
     "@tiptap/extension-heading": "^2.0.0-beta.26",
     "@tiptap/extension-highlight": "^2.0.0-beta.220",
     "@tiptap/extension-history": "^2.0.0-beta.21",
-    "@tiptap/extension-horizontal-rule": "^2.0.4",
+    "@tiptap/extension-horizontal-rule": "2.0.0-beta.36",
     "@tiptap/extension-image": "^2.0.0-beta.27",
     "@tiptap/extension-italic": "^2.0.0-beta.26",
     "@tiptap/extension-link": "^2.0.0-beta.36",


### PR DESCRIPTION
I only added the tiptap HorizontalRule extension to the EditorNodes.ts file. So that the color of the line can be seen in each mode (dark / light), I used a neutral gray in the css rules.

I noticed that when the cursor was on the line, it made the toolbar appear and did not highlight the line like on skiff-page. This solution, even if it works, may be incomplete since I don't have access to the skiff-page code to see how it was implemented