### PR TITLE
add: application name in manifest

### DIFF
--- a/skemail-web/public/favicon/site.webmanifest
+++ b/skemail-web/public/favicon/site.webmanifest
@@ -1,6 +1,6 @@
 {
-    "name": "",
-    "short_name": "",
+    "name": "Skiff Mail",
+    "short_name": "Skiff Mail",
     "icons": [
         {
             "src": "/android-chrome-192x192.png",


### PR DESCRIPTION
application used to show react-client while install as PWA popup as there wasn't any name present in the manifest